### PR TITLE
Add macOS overlay and whisper wrapper improvements

### DIFF
--- a/examples/WhisperSpotlight/GlobalHotkey.swift
+++ b/examples/WhisperSpotlight/GlobalHotkey.swift
@@ -1,0 +1,25 @@
+import Carbon
+import Foundation
+
+class GlobalHotkey {
+    var handler: (() -> Void)?
+    private var ref: EventHotKeyRef?
+
+    init(keyCode: UInt32, modifiers: UInt32) {
+        var hotKeyID = EventHotKeyID(signature: OSType(0x1234), id: UInt32(keyCode))
+        RegisterEventHotKey(keyCode, modifiers, hotKeyID, GetApplicationEventTarget(), 0, &ref)
+        let eventSpec = EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed))
+        InstallEventHandler(GetApplicationEventTarget(), { _, evt, ctx in
+            let hotKeyIDPtr = UnsafeMutablePointer<EventHotKeyID>.allocate(capacity: 1)
+            GetEventParameter(evt!, EventParamName(kEventParamDirectObject), EventParamType(typeEventHotKeyID), nil, MemoryLayout<EventHotKeyID>.size, nil, hotKeyIDPtr)
+            Unmanaged<GlobalHotkey>.fromOpaque(ctx!).takeUnretainedValue().handler?()
+            return noErr
+        }, 1, [eventSpec], Unmanaged.passUnretained(self).toOpaque(), nil)
+    }
+
+    deinit {
+        if let ref { UnregisterEventHotKey(ref) }
+    }
+}
+
+let optionKey: UInt32 = UInt32(cmdKey) >> 8

--- a/examples/WhisperSpotlight/ModelManager.swift
+++ b/examples/WhisperSpotlight/ModelManager.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+struct ModelManager {
+    private let fileManager = FileManager.default
+    private let modelFile = "ggml-large-v3-turbo.bin"
+    private let url = URL(string: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin")!
+
+    func modelPath() -> URL {
+        let app = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appending(path: "WhisperSpotlight")
+        try? fileManager.createDirectory(at: app, withIntermediateDirectories: true)
+        return app.appending(path: modelFile)
+    }
+
+    func ensureModel(progress: ((Double) -> Void)? = nil) async throws {
+        let path = modelPath()
+        if fileManager.fileExists(atPath: path.path) { return }
+        try await downloadModel(to: path, progress: progress)
+    }
+
+    private func downloadModel(to path: URL, progress: ((Double) -> Void)?) async throws {
+        let request = URLRequest(url: url)
+        for _ in 0..<3 {
+            do {
+                let (temp, response) = try await URLSession.shared.download(for: request, delegate: ProgressDelegate(progress))
+                guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else { throw URLError(.badServerResponse) }
+                try fileManager.moveItem(at: temp, to: path)
+                let attr = try fileManager.attributesOfItem(atPath: path.path)
+                if let size = attr[.size] as? NSNumber, size.intValue > 1_400_000_000 { return }
+            } catch {
+                try? fileManager.removeItem(at: path)
+                continue
+            }
+        }
+        throw URLError(.cannotCreateFile)
+    }
+}
+
+private class ProgressDelegate: NSObject, URLSessionTaskDelegate {
+    let callback: ((Double) -> Void)?
+    init(_ cb: ((Double) -> Void)?) { self.callback = cb }
+    func urlSession(_ session: URLSession, task: URLSessionTask, didSendBodyData bytesSent: Int64, totalBytesSent: Int64, totalBytesExpectedToSend: Int64) {
+        if totalBytesExpectedToSend > 0 {
+            callback?(Double(totalBytesSent)/Double(totalBytesExpectedToSend))
+        }
+    }
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
+        if totalBytesExpectedToWrite > 0 {
+            callback?(Double(totalBytesWritten)/Double(totalBytesExpectedToWrite))
+        }
+    }
+}

--- a/examples/WhisperSpotlight/OverlayView.swift
+++ b/examples/WhisperSpotlight/OverlayView.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+import AppKit
+
+enum OverlayState {
+    case idle, listening, transcribing(String), done(String)
+}
+
+struct OverlayView: View {
+    @State private var state: OverlayState = .idle
+    @State private var recorder = Recorder()
+    @State private var modelURL: URL? = nil
+    @State private var manager = ModelManager()
+    @State private var task: Task<Void, Never>? = nil
+
+    var body: some View {
+        VStack {
+            switch state {
+            case .idle:
+                Image(systemName: "mic")
+                    .onTapGesture { toggleListening() }
+            case .listening:
+                ProgressView("Listening…")
+                    .onAppear { startRecording() }
+            case .transcribing(let text):
+                ProgressView(text)
+            case .done(let text):
+                Text(text)
+            }
+        }
+        .frame(width: 320, height: 200)
+        .background(Material.thick)
+        .cornerRadius(12)
+        .onReceive(NotificationCenter.default.publisher(for: .toggleOverlay)) { _ in
+            toggleListening()
+        }
+    }
+
+    private func toggleListening() {
+        switch state {
+        case .idle: state = .listening
+        case .listening: stopRecording()
+        default: break
+        }
+    }
+
+    private func startRecording() {
+        task = Task {
+            do {
+                try await manager.ensureModel()
+                let file = try FileManager.default
+                    .temporaryDirectory.appending(path: "record.wav")
+                try await recorder.startRecording(toOutputFile: file, delegate: nil)
+            } catch {}
+        }
+    }
+
+    private func stopRecording() {
+        task?.cancel()
+        Task {
+            recorder.stopRecording()
+            if let url = recorder.currentFile {
+                state = .transcribing("Transcribing…")
+                let ctx = try? WhisperContext.createContext(path: manager.modelPath().path())
+                if let data = try? decodeWaveFile(url) {
+                    ctx?.fullTranscribe(samples: data, language: "")
+                    let text = ctx?.getTranscription() ?? ""
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(text, forType: .string)
+                    state = .done(text)
+                }
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                state = .idle
+            }
+        }
+    }
+}
+
+extension Notification.Name {
+    static let toggleOverlay = Notification.Name("ToggleOverlay")
+}

--- a/examples/WhisperSpotlight/Package.swift
+++ b/examples/WhisperSpotlight/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version:5.7
+import PackageDescription
+
+let package = Package(
+    name: "WhisperSpotlight",
+    platforms: [.macOS(.v13)],
+    products: [
+        .library(name: "WhisperSpotlight", targets: ["WhisperSpotlight"])
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "WhisperSpotlight", dependencies: [], path: "", exclude: ["Tests"]),
+        .testTarget(name: "WhisperSpotlightTests", dependencies: ["WhisperSpotlight"], path: "Tests")
+    ]
+)

--- a/examples/WhisperSpotlight/Recorder.swift
+++ b/examples/WhisperSpotlight/Recorder.swift
@@ -1,0 +1,26 @@
+import Foundation
+import AVFoundation
+
+actor Recorder {
+    private var recorder: AVAudioRecorder?
+    private(set) var currentFile: URL?
+
+    func startRecording(toOutputFile url: URL, delegate: AVAudioRecorderDelegate?) throws {
+        currentFile = url
+        let settings: [String: Any] = [
+            AVFormatIDKey: Int(kAudioFormatLinearPCM),
+            AVSampleRateKey: 16000.0,
+            AVNumberOfChannelsKey: 1,
+            AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
+        ]
+        let rec = try AVAudioRecorder(url: url, settings: settings)
+        rec.delegate = delegate
+        guard rec.record() else { throw NSError(domain: "rec", code: 1) }
+        recorder = rec
+    }
+
+    func stopRecording() {
+        recorder?.stop()
+        recorder = nil
+    }
+}

--- a/examples/WhisperSpotlight/RiffWaveUtils.swift
+++ b/examples/WhisperSpotlight/RiffWaveUtils.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+func decodeWaveFile(_ url: URL) throws -> [Float] {
+    let data = try Data(contentsOf: url)
+    let floats = stride(from: 44, to: data.count, by: 2).map {
+        return data[$0..<$0 + 2].withUnsafeBytes {
+            let short = Int16(littleEndian: $0.load(as: Int16.self))
+            return max(-1.0, min(Float(short) / 32767.0, 1.0))
+        }
+    }
+    return floats
+}

--- a/examples/WhisperSpotlight/Tests/IntegrationTests.swift
+++ b/examples/WhisperSpotlight/Tests/IntegrationTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import WhisperSpotlight
+
+final class IntegrationTests: XCTestCase {
+    func testClipboardWrite() throws {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString("hello", forType: .string)
+        XCTAssertEqual(NSPasteboard.general.string(forType: .string), "hello")
+    }
+}

--- a/examples/WhisperSpotlight/Tests/ModelManagerTests.swift
+++ b/examples/WhisperSpotlight/Tests/ModelManagerTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import WhisperSpotlight
+
+final class ModelManagerTests: XCTestCase {
+    func testModelPathCreation() throws {
+        let manager = ModelManager()
+        let path = manager.modelPath()
+        XCTAssertTrue(path.path.contains("WhisperSpotlight"))
+    }
+}

--- a/examples/WhisperSpotlight/Tests/RecorderTests.swift
+++ b/examples/WhisperSpotlight/Tests/RecorderTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+@testable import WhisperSpotlight
+
+final class RecorderTests: XCTestCase {
+    func testWavHeader() async throws {
+        let recorder = Recorder()
+        let url = FileManager.default.temporaryDirectory.appending(path: "test.wav")
+        try await recorder.startRecording(toOutputFile: url, delegate: nil)
+        recorder.stopRecording()
+        let data = try Data(contentsOf: url)
+        XCTAssertEqual(String(data: data.prefix(4), encoding: .ascii), "RIFF")
+    }
+}

--- a/examples/WhisperSpotlight/WhisperSpotlightApp.swift
+++ b/examples/WhisperSpotlight/WhisperSpotlightApp.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+@main
+struct WhisperSpotlightApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var delegate
+    var body: some Scene {
+        WindowGroup {
+            OverlayView()
+        }
+    }
+}
+
+class AppDelegate: NSObject, NSApplicationDelegate {
+    private var hotkey: GlobalHotkey?
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        hotkey = GlobalHotkey(keyCode: kVK_Space, modifiers: optionKey)
+        hotkey?.handler = {
+            NotificationCenter.default.post(name: .toggleOverlay, object: nil)
+        }
+    }
+}

--- a/examples/WhisperSpotlight/whispercpp/LibWhisper.swift
+++ b/examples/WhisperSpotlight/whispercpp/LibWhisper.swift
@@ -1,5 +1,5 @@
 import Foundation
-import UIKit
+import AppKit
 import whisper
 
 enum WhisperError: Error {
@@ -122,8 +122,8 @@ actor WhisperContext {
 
         whisper_print_timings(context)
 
-        let deviceModel = await UIDevice.current.model
-        let systemName = await UIDevice.current.systemName
+        let deviceModel = Host.current().localizedName ?? "Mac"
+        let systemName = ProcessInfo.processInfo.operatingSystemVersionString
         let systemInfo = self.systemInfo()
         let timings: whisper_timings = whisper_get_timings(context).pointee
         let encodeMs = String(format: "%.2f", timings.encode_ms)


### PR DESCRIPTION
## Summary
- update Swift wrapper for optional language parameter
- create macOS overlay example `WhisperSpotlight`
- add model download manager with retry and progress
- register global hotkey and overlay UI
- add tests for recorder, model manager, and integration

## Testing
- `swift test -l` *(fails: no such module 'Carbon')*

------
https://chatgpt.com/codex/tasks/task_e_68443e22bd908326b0f8188295c0d1c0